### PR TITLE
Add destroy method to callbacks list

### DIFF
--- a/callback-methods.js
+++ b/callback-methods.js
@@ -16,5 +16,6 @@ module.exports = [
   'finalize',
   'append',
   'flush',
-  'audit'
+  'audit',
+  'destroy'
 ]


### PR DESCRIPTION
The new [destroy method](https://github.com/mafintosh/hypercore/pull/250) in hypercore enables you to delete all the hypercore's data and close it.

It'd be nice to be able to use this with promises. 😁