### PR TITLE
Added `destroyData` to callbacks

### DIFF
--- a/callback-methods.js
+++ b/callback-methods.js
@@ -17,5 +17,6 @@ module.exports = [
   'append',
   'flush',
   'audit',
-  'destroy'
+  'destroy',
+  'destroyData'
 ]


### PR DESCRIPTION
There were complaints that `feed.destroy` might be confusing since it's not always a destructive method name. With that in mind, I renamed it to `destroyData` so that it'd be more explicit as to what it does.

It'd be nice to get this into the promise wrapper so that it can be used in the Dat-SDK project.